### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Please see also the [INSTALL](http://versor.mat.ucsb.edu/INSTALL.html) guide.  F
 
 To test a graphics example
 
-	make tests/xBasics.cpp 
+	make examples/xBasic.cpp 
      
 which both builds and runs the file.  
 


### PR DESCRIPTION
"tests/xBasics.cpp" doesn't exist in project structure. Updated README to reflect this and replaced it with "examples/xBasic.cpp"
