### PR TITLE
Update the repo link for glew

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -104,7 +104,7 @@ cd into glew folder:
 
 or clone from current repos:
 
-	git clone git://glew.git.sourceforge.net/gitroot/glew/glew
+	git clone https://github.com/nigels-com/glew.git glew
 	cd glew
 	make extensions
 	sudo make install


### PR DESCRIPTION
I noticed the git clone command is now the one I changed it to after looking at the sourceforge.net link.