### PR TITLE
Fix clang++ (version 20.1.8) compile errors.

### DIFF
--- a/include/vsr/detail/vsr_algebra.h
+++ b/include/vsr/detail/vsr_algebra.h
@@ -210,7 +210,7 @@ namespace vsr {
            typedef gp_basis_t<typename B::basis, typename A::basis > tmp_basis;
            //............................................lh...........rh.................return type
            using x = typename impl::template rot_arrow_t<tmp_basis, typename B::basis, typename A::basis>;
-           return x::Arrow::template Make<A>( gp(b, a), Reverse<typename B::basis>::Type::template Make(b) );
+           return x::Arrow::template Make<A>( gp(b, a), Reverse<typename B::basis>::Type::template Make<B>(b) );
          }
 
          /// Reflect a by b, return type a
@@ -218,7 +218,7 @@ namespace vsr {
          static constexpr A reflect(const A& a, const B& b) {
           typedef gp_basis_t<typename B::basis, typename A::basis > tmp_basis;
           using x = typename impl::template rot_arrow_t<tmp_basis, typename B::basis, typename A::basis>;
-          return x::Arrow::template Make<A>( gp(b, a.involution() ), Reverse<typename B::basis>::Type::template Make(b) );
+          return x::Arrow::template Make<A>( gp(b, a.involution() ), Reverse<typename B::basis>::Type::template Make<B>(b) );
          }
 
           /// make a type from sum of basis B1 and B2

--- a/include/vsr/detail/vsr_multivector.h
+++ b/include/vsr/detail/vsr_multivector.h
@@ -194,7 +194,7 @@ namespace vsr{
 
       /// Reversion \\(\\tilde{A}\\)
       Multivector operator ~() const {
-        return Reverse< basis >::Type::template Make(*this) ;
+        return Reverse< basis >::Type::template Make<Multivector>(*this) ;
       }
 
       /// Inversion \\(\\tilde{A}/A\\tilde{A}\\)
@@ -448,11 +448,11 @@ Multivector<Algebra,B> Multivector<Algebra,B>::yz = Multivector<Algebra,B>().tem
  *-----------------------------------------------------------------------------*/
 template<typename Algebra, typename B>
 Multivector<Algebra,B> Multivector<Algebra,B>::conjugation() const{
-	return Conjugate<B>::Type::template Make(*this);
+	return Conjugate<B>::Type::template Make<Multivector>(*this);
 }
 template<typename Algebra, typename B>
 Multivector<Algebra,B> Multivector<Algebra,B>::involution() const{
-	return Involute<B>::Type::template Make(*this);
+	return Involute<B>::Type::template Make<Multivector>(*this);
 }
 
 

--- a/include/vsr/form/vsr_chain.h
+++ b/include/vsr/form/vsr_chain.h
@@ -22,7 +22,7 @@
 #include <vsr/form/vsr_rigid.h>
 
 #include <map>
-#include <string>
+#include <cstring>
 
 namespace vsr{ namespace cga {
 


### PR DESCRIPTION
error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]

error: ‘strncmp’ was not declared in this scope

Personally I'd use `std::strncmp`, but for backwards compatibility with C `strncmp` is also made available in global namespace, so it works like this. Not even sure if that is guaranteed by C++ though (probably not).

Also, I removed the `#include <string>` because this file doesn't use `std::string` anywhere. It DOES use `string`, but whatever that is, it wouldn't compile anyway, with or without <string>, if that wasn't already defined elsewhere (again, one should use `std::string` if it is the C++ standard string).