### PR TITLE
Use quoted include for tests/Common.h.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,6 @@ endif()
 
 
 #project include directories
-include_directories(BEFORE ${PROJECT_SOURCE_DIR})
 include_directories(BEFORE ${PROJECT_SOURCE_DIR}/include)
 
 #CORE TEST TARGETS -- all files in tests get built to test math library functionality

--- a/tests/AlgebraTests.cpp
+++ b/tests/AlgebraTests.cpp
@@ -1,5 +1,5 @@
+#include "Common.h"
 #include <gtest/gtest.h>
-#include <tests/Common.h>
 #include <vsr/detail/vsr_algebra.h>
 
 using namespace vsr;

--- a/tests/BasisTests.cpp
+++ b/tests/BasisTests.cpp
@@ -1,5 +1,5 @@
+#include "Common.h"
 #include <gtest/gtest.h>
-#include <tests/Common.h>
 #include <vsr/detail/vsr_basis.h>
 
 using namespace vsr;

--- a/tests/InstructionsTest.cpp
+++ b/tests/InstructionsTest.cpp
@@ -1,6 +1,5 @@
-
+#include "Common.h"
 #include <gtest/gtest.h>
-#include <tests/Common.h>
 #include <vsr/detail/vsr_xlists.h>
 #include <vsr/detail/vsr_instructions.h>
 

--- a/tests/MultivectorTest.cpp
+++ b/tests/MultivectorTest.cpp
@@ -1,5 +1,5 @@
+#include "Common.h"
 #include <gtest/gtest.h>
-#include <tests/Common.h>
 #include <vsr/detail/vsr_multivector.h>
 #include <vsr/detail/vsr_generic_op.h>
 

--- a/tests/ProductTests.cpp
+++ b/tests/ProductTests.cpp
@@ -1,5 +1,5 @@
+#include "Common.h"
 #include <gtest/gtest.h>
-#include <tests/Common.h>
 #include <vsr/detail/vsr_products.h>
 
 // Test Metric

--- a/tests/XListsTests.cpp
+++ b/tests/XListsTests.cpp
@@ -1,5 +1,5 @@
+#include "Common.h"
 #include <gtest/gtest.h>
-#include <tests/Common.h>
 #include <vsr/detail/vsr_xlists.h>
 
 using namespace vsr;


### PR DESCRIPTION
The directory tests/ has a single header (Common.h) that is included only by .cpp files in the same directory.

Using the quote form makes the preprocessor first look for the header in the directory of the .cpp file that includes it, and only then the include paths. In general one should use the quoted form when including a header from the same directory, or a subdirectory (it avoids name collisions with externally installed (system) headers).

In this case we can remove the include directory of the root of the project now, too, because tests/Common.h is the only header that required that.