### PR TITLE
Improve build.sh.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ To build library
 
 	./build.sh
 
+Run
+
+    ./build.sh --help
+
+for a list of possible options.
+
 To build library and examples:
 
 	./build.sh --examples
@@ -146,7 +152,13 @@ You can add your own file to the list of targets by adding it to /examples or sc
 
 INSTALLATION
 ---
-Hmmm, haven't added install options yet!  Will do so soon I promise.
+
+To configure, build and install the project you can run for example:
+
+    ./build.sh --install -j 8
+
+This will run `sudo cmake --install`, after configuration and building, and currently installs with prefix /usr/local.
+Please use cmake directly if you need a different prefix.
 
 Use Cases
 ---

--- a/build.sh
+++ b/build.sh
@@ -9,28 +9,67 @@ MAKE_VERBOSE=1
 DO_INSTALL=0
 DO_UPDATE=0
 USE_DOUBLE_PRECISION=1
+JOBS=4
 
-for i
+# This environment variable is used by cmake.
+export VERBOSE=1
+
+# Decode commandline arguments.
+while [ $# -gt 0 ]
 do
-  case $i in
-  -m | --math)
-    BUILD_GRAPHICS=0
-  ;;
-  -x | --examples)
-    BUILD_EXAMPLES=1
-  ;;
-  -q | --quiet)
-    MAKE_VERBOSE=0
-  ;;
-  -i | --install)
-    DO_INSTALL=1
-  ;;
-  -u | --update)
-    DO_UPDATE=1
-  ;;
-  -f | --float)
-    USE_DOUBLE_PRECISION=0
+  case $1 in
+    -m|--math)        BUILD_GRAPHICS=0 ;;
+    -x|--examples)    BUILD_EXAMPLES=1 ;;
+    -q|--quiet)       MAKE_VERBOSE=0; unset VERBOSE ;;
+    -i|--install)     DO_INSTALL=1 ;;
+    -u|--update)      DO_UPDATE=1 ;;
+    -f|--float)       USE_DOUBLE_PRECISION=0 ;;
+
+    # -j with separate argument.
+    -j|--parallel)
+      shift || { echo "Error: missing value for $1." >&2; exit 2; }
+      JOBS=$1
+      ;;
+
+    # -j<NUM> compact form.
+    -j*[0-9]*)
+      JOBS=${1#-j}
+      ;;
+
+    # --parallel=<NUM> form.
+    --parallel=*)
+      JOBS=${1#--parallel=}
+      ;;
+
+    -h|--help)
+      echo "Usage: build.sh [OPTION]..."
+      echo "Configure and build versor."
+      echo "  -h, --help         print a short overview of options."
+      echo "  -i, --install      install headers and static library in /usr/local."
+      echo "  -j, --parallel=N   build using N jobs in parallel."
+      echo "  -m, --math         math only (no graphics)."
+      echo "  -q, --quiet        turn verbose build off."
+      echo "  -u, --update       update git submodules before building."
+      echo "  -x, --examples     build the examples."
+      exit 0
+      ;;
+
+    --) # End of options.
+      shift
+      break
+      ;;
+
+    -*) # Unknown option.
+      echo "Error: unknown option: $1" >&2
+      exit 2
+      ;;
+
+    *) # Positional arg
+      posargs="$posargs${posargs:+ }$1"
+      echo "Unused positional argument: \"${posargs}\"."
+      ;;
   esac
+  shift
 done
 
 if [ $DO_UPDATE = 1 ]; then
@@ -39,12 +78,19 @@ fi
 
 cmake --version
 BUILD_DIRECTORY=build
-mkdir -p $BUILD_DIRECTORY
-cd $BUILD_DIRECTORY
-cmake -DBUILD_DIRECTORY=$BUILD_DIRECTORY -DBUILD_GRAPHICS=$BUILD_GRAPHICS -DBUILD_EXAMPLES=$BUILD_EXAMPLES -DBUILD_SCRATCH=$BUILD_SCRATCH -DUSE_DOUBLE_PRECISION=$USE_DOUBLE_PRECISION -DCMAKE_EXPORT_COMPILE_COMMANDS=1 ..
 
-make VERBOSE=$MAKE_VERBOSE
+# Configure.
+cmake -B $BUILD_DIRECTORY \
+  -DCMAKE_VERBOSE_MAKEFILE=$MAKE_VERBOSE \
+  -DCMAKE_EXPORT_COMPILE_COMMANDS=1 \
+  -DBUILD_DIRECTORY=$BUILD_DIRECTORY \
+  -DBUILD_GRAPHICS=$BUILD_GRAPHICS \
+  -DBUILD_EXAMPLES=$BUILD_EXAMPLES \
+  -DUSE_DOUBLE_PRECISION=$USE_DOUBLE_PRECISION
+
+# Build.
+cmake --build $BUILD_DIRECTORY --parallel $JOBS
 
 if [ $DO_INSTALL = 1 ]; then
-  make install
+  sudo cmake --install $BUILD_DIRECTORY --parallel $JOBS
 fi


### PR DESCRIPTION
Adds options:
  -j, --parallel=N   build using N jobs in parallel.
  -h, --help         print a short overview of options.

Do not create the `build` directory (cmake already does that). Do not cd into the `build` directory (now you can run build.sh from any directory using a full path to it; although the build directory will be created in the current directory from where you run it).

Use cmake to build the project and to install it. This is more portable (for example supports a portable --parallel N option).